### PR TITLE
Bug/703

### DIFF
--- a/parser-tests/analizadorLineaTest.c
+++ b/parser-tests/analizadorLineaTest.c
@@ -69,8 +69,14 @@ context (parser) {
 
         it("liberar") {
             analizadorLinea("liberar x", funciones, kernel);
-                t_puntero posicionX = assertObtenerPosicion('x');
-                assertLiberar(posicionX);
+            t_valor_variable valorX = assertDereferenciar(assertObtenerPosicion('x'));
+            assertLiberar(valorX);
+        } end
+
+        it("liberar se puede operar como cualquier asignacion") {
+            analizadorLinea("liberar x+5", funciones, kernel);
+            t_valor_variable valorX = assertDereferenciar(assertObtenerPosicion('x'));
+            assertLiberar(valorX + 5);
         } end
 
         it("imprimir un valor") {

--- a/parser-tests/analizadorLineaTest.c
+++ b/parser-tests/analizadorLineaTest.c
@@ -73,6 +73,12 @@ context (parser) {
             assertLiberar(valorX);
         } end
 
+        it("liberar una posicion") {
+            analizadorLinea("liberar &x", funciones, kernel);
+            t_valor_variable posicionX = assertObtenerPosicion('x');
+            assertLiberar(posicionX);
+        } end
+
         it("liberar se puede operar como cualquier asignacion") {
             analizadorLinea("liberar x+5", funciones, kernel);
             t_valor_variable valorX = assertDereferenciar(assertObtenerPosicion('x'));

--- a/parser/parser/parser.c
+++ b/parser/parser/parser.c
@@ -161,7 +161,7 @@ void analizadorLinea(char* const instruccion, AnSISOP_funciones *AnSISOP_funcion
 		free(operation);
 	} else if( _esLiberar(linea) ){
 		//FREE POSICION
-		AnSISOP_funciones_kernel->AnSISOP_liberar( _obtenerPosicion(_string_trim(linea + strlen(TEXT_FREE)), AnSISOP_funciones) );
+		AnSISOP_funciones_kernel->AnSISOP_liberar( _operar(_string_trim(linea + strlen(TEXT_FREE)), AnSISOP_funciones) );
 	} else if( _esLlamadaFuncion(linea) ){
 		//RETORNO <- ETIQUETA PARAMETROS
 		char* *ret = _separarOperadores(linea, TEXT_CALL);


### PR DESCRIPTION
https://github.com/sisoputnfrba/foro/issues/703
```
		/*
		 * LIBERAR MEMORIA
		 *
		 * Informa al kernel que libera la memoria previamente reservada con RESERVAR.
		 * Solo se podra liberar memoria previamente asignada con RESERVAR.
		 *
		 * @sintax	TEXT_FREE (liberar)
		 * @param	puntero Inicio de espacio de memoria a liberar (previamente retornado por RESERVAR)
		 * @return	void
		 */
		void (*AnSISOP_liberar)(t_puntero puntero);
```
debería ser el valor de x, no la posición de x.