### PR TITLE
limpiar el contexto en cada test

### DIFF
--- a/parser-tests/analizadorLineaTest.c
+++ b/parser-tests/analizadorLineaTest.c
@@ -161,15 +161,15 @@ context (parser) {
 
          it("leer de un archivo") {
              analizadorLinea("leer 1 t 4-2", funciones, kernel);
-             t_puntero posicionT = assertObtenerPosicion('t');
-             assertLeer(1, posicionT, 4-2);
+             t_puntero valorT = assertDereferenciar(assertObtenerPosicion('t'));
+             assertLeer(1, valorT, 4-2);
          } end
 
          it("leer de un archivo con fd que sea una variable") {
              analizadorLinea("leer a t 2", funciones, kernel);
-             t_puntero posicionT = assertObtenerPosicion('t');
-             t_valor_variable valorA = assertDereferenciar(assertObtenerPosicion('a'));
-             assertLeer(valorA, posicionT, 2);
+             t_puntero valorT = assertDereferenciar(assertObtenerPosicion('t'));
+             t_descriptor_archivo valorA = assertDereferenciar(assertObtenerPosicion('a'));
+             assertLeer(valorA, valorT, 2);
          } end
 
          it("escribir en un archivo") {

--- a/parser/parser/parser.c
+++ b/parser/parser/parser.c
@@ -128,7 +128,7 @@ void analizadorLinea(char* const instruccion, AnSISOP_funciones *AnSISOP_funcion
 		char **operation = string_split(linea + strlen(TEXT_READ_FILE), " ");
 		AnSISOP_funciones_kernel->AnSISOP_leer(
 				(t_descriptor_archivo) _operar(operation[0], AnSISOP_funciones),
-				_obtenerPosicion(operation[1], AnSISOP_funciones),
+				(t_puntero) _operar(operation[1], AnSISOP_funciones),
 				_operar(operation[2], AnSISOP_funciones)
 		);
 		free(operation);


### PR DESCRIPTION
Hacerq ue el `leer` use el *valor* del parametro de información, y no su puntero.

https://github.com/sisoputnfrba/foro/issues/772